### PR TITLE
MySQLからPostgreSQLへ移行

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,8 +5,10 @@ source "https://rubygems.org"
 git_source(:github) {|repo_name| "https://github.com/#{repo_name}" }
 
 gem 'mysql2'
+gem 'pg'
 gem 'activerecord'
 gem 'activesupport'
 gem 'http'
 gem 'dotenv'
 gem 'slack-incoming-webhooks'
+gem 'ridgepole'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -15,6 +15,7 @@ GEM
     addressable (2.7.0)
       public_suffix (>= 2.0.2, < 5.0)
     concurrent-ruby (1.1.6)
+    diffy (3.4.0)
     domain_name (0.5.20190701)
       unf (>= 0.0.5, < 1.0.0)
     dotenv (2.7.5)
@@ -36,8 +37,12 @@ GEM
       concurrent-ruby (~> 1.0)
     minitest (5.14.1)
     mysql2 (0.5.3)
+    pg (1.2.3)
     public_suffix (4.0.6)
     rake (13.0.1)
+    ridgepole (0.8.12)
+      activerecord (>= 5.0.1, < 6.1)
+      diffy
     slack-incoming-webhooks (0.3.0)
     thread_safe (0.3.6)
     tzinfo (1.2.7)
@@ -56,6 +61,8 @@ DEPENDENCIES
   dotenv
   http
   mysql2
+  pg
+  ridgepole
   slack-incoming-webhooks
 
 BUNDLED WITH

--- a/Schemafile
+++ b/Schemafile
@@ -1,0 +1,8 @@
+create_table "remo_logs", force: :cascade do |t|
+  t.decimal "humidity", precision: 10, scale: 1
+  t.decimal "illumination", precision: 10, scale: 2
+  t.boolean "motion"
+  t.decimal "temperature", precision: 10, scale: 1
+  t.datetime "created_at"
+  t.datetime "updated_at"
+end

--- a/database.yml
+++ b/database.yml
@@ -1,0 +1,12 @@
+default: &default
+  adapter: mysql2
+  database: <%= ENV['DB_DATABASE'] %>
+  host: <%= ENV['DB_HOST'] %>
+  username: <%= ENV['DB_USERNAME'] %>
+  password: <%= ENV['DB_PASSWORD'] %>
+
+development:
+  <<: *default
+
+production:
+  <<: *default

--- a/database.yml
+++ b/database.yml
@@ -1,11 +1,10 @@
-development:
+default: &default
   adapter: postgresql
   encoding: unicode
-  url: postgres://localhost:5432/nature_remo_log_development
+  url: <%= ENV['DATABASE_URL'] %>
+
+development:
+  <<: *default
 
 production:
-  adapter: mysql2
-  database: <%= ENV['DB_DATABASE'] %>
-  host: <%= ENV['DB_HOST'] %>
-  username: <%= ENV['DB_USERNAME'] %>
-  password: <%= ENV['DB_PASSWORD'] %>
+  <<: *default

--- a/database.yml
+++ b/database.yml
@@ -1,12 +1,11 @@
-default: &default
+development:
+  adapter: postgresql
+  encoding: unicode
+  url: postgres://localhost:5432/nature_remo_log_development
+
+production:
   adapter: mysql2
   database: <%= ENV['DB_DATABASE'] %>
   host: <%= ENV['DB_HOST'] %>
   username: <%= ENV['DB_USERNAME'] %>
   password: <%= ENV['DB_PASSWORD'] %>
-
-development:
-  <<: *default
-
-production:
-  <<: *default

--- a/main.rb
+++ b/main.rb
@@ -22,15 +22,10 @@ end
 begin
   remo = fetch_remo.first['newest_events']
   RemoLog.create(
-    measured_at: Time.now,
     humidity: remo.dig('hu', 'val'),
-    humidity_created_at: remo.dig('hu', 'created_at'),
     illumination: remo.dig('il', 'val'),
-    illumination_created_at: remo.dig('il', 'created_at'),
     motion: remo.dig('mo', 'val'),
-    motion_created_at: remo.dig('mo', 'created_at'),
     temperature: remo.dig('te', 'val'),
-    temperature_created_at: remo.dig('te', 'created_at'),
   )
 rescue => e
   SlackClient.new.post <<~"EOS"

--- a/main.rb
+++ b/main.rb
@@ -1,17 +1,13 @@
 require 'uri'
 require 'json'
 require 'http'
+require 'erb'
 require 'active_record'
 require 'dotenv/load'
 require './slack_client'
 
-ActiveRecord::Base.establish_connection(
-  adapter: 'mysql2',
-  database: ENV['DB_DATABASE'],
-  host: ENV['DB_HOST'],
-  username: ENV['DB_USERNAME'],
-  password: ENV['DB_PASSWORD']
-)
+config = YAML::load(ERB.new(IO.read('./database.yml')).result)
+ActiveRecord::Base.establish_connection(config.fetch(ENV.fetch('RUBY_ENV') { 'production' }))
 Time.zone_default = Time.find_zone! 'Tokyo'
 ActiveRecord::Base.default_timezone = :local
 


### PR DESCRIPTION
- dbの設定をdatabase.ymlに切り出し
- ridgepoleを導入
- remo_logsから不要なカラムを削除
- dbの接続先をHerokuのMySQLからPostgreSQLに移行

開発環境でのスキーマ適用方法：
`bundle exec dotenv -f ".env" ridgepole -c database.yml -E development --apply`

本番環境でのスキーマ適用方法：
`ridgepole -c env:DATABASE_URL -E production --apply`